### PR TITLE
Encode library.properties as UTF-8

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-﻿name=Stepper Motor Shield IFX9201 XMC1300
+name=Stepper Motor Shield IFX9201 XMC1300
 version=1.0.0
 author=Infineon Technologies
 maintainer=Infineon Technologies AG <www.infineon.com>


### PR DESCRIPTION
The previous UTF-8 BOM encoding caused installation of the library via the recommended "Add ZIP Library" method to fail silently.

Manual installation resulted in the library not being recognized and a warning from the Arduino IDE on every compilation:
```
Missing 'name' from library in E:\arduino\libraries\Stepper-Motor-Shield-IFX9201-XMC1300
```